### PR TITLE
Fix NoMethodError on creating issue via API

### DIFF
--- a/lib/issues_status_hook.rb
+++ b/lib/issues_status_hook.rb
@@ -17,7 +17,7 @@ class IssueStatusHook < Redmine::Hook::ViewListener
 		setting[:status_assigned_to].each { |s, a|
 			unless a.blank?
 				f = issue.custom_field_values.find { |f| f.custom_field_id == Integer(a) }
-				status_to_user[Integer(s)] = Integer(f.value) if f && !f.value.empty?
+				status_to_user[Integer(s)] = Integer(f.value) if f && f.value && !f.value.empty?
 			end }
 		status_to_user
 		issue.assigned_to_id = status_to_user[issue.status_id] if status_to_user[issue.status_id]


### PR DESCRIPTION
NoMethodError always occurs when an issue is created via POST API.

```
Started POST "/redmine/projects/test/issues.json" for xxxx::xxxx:xxxx:xxxx:xxxx at 2017-08-25 11:21:33 +0900 Processing by IssuesController#create as JSON
  Parameters: {"issue"=>{"description"=>"bbb", "subject"=>"aaa"}, "project_id"=>"test"}
  Current user: xxxxxxxx (id=17)
Completed 500 Internal Server Error in 16ms (ActiveRecord: 0.0ms)

NoMethodError (undefined method `empty?' for nil:NilClass):
  plugins/status_button/lib/issues_status_hook.rb:20:in `block in update_issues'
  plugins/status_button/lib/issues_status_hook.rb:17:in `update_issues'
  plugins/status_button/lib/issues_status_hook.rb:4:in `controller_issues_new_before_save'
  lib/redmine/hook.rb:61:in `block (2 levels) in call_hook'
  lib/redmine/hook.rb:61:in `each'
  lib/redmine/hook.rb:61:in `block in call_hook'
  lib/redmine/hook.rb:58:in `tap'
  lib/redmine/hook.rb:58:in `call_hook'
  lib/redmine/hook.rb:91:in `call_hook'
  app/controllers/issues_controller.rb:143:in `create'
  lib/redmine/sudo_mode.rb:63:in `sudo_mode'
```

Environment:
```
  Redmine version                3.3.3.stable
  Ruby version                   2.1.9-p490 (2016-03-30) [i386-mingw32]
  Rails version                  4.2.7.1
  Environment                    production
  Database adapter               Mysql2
```
