### PR TITLE
Incompatible with Redmine 3.4

### DIFF
--- a/app/views/settings/_status_button_settings.html.erb
+++ b/app/views/settings/_status_button_settings.html.erb
@@ -1,15 +1,15 @@
 <%	memberFields = CustomField.all.select { |f| f.class.name == 'IssueCustomField' && f.field_format == 'user' }
 	options = memberFields.map{ |f| [f.name, f.id] }
-	@settings = {:status_assigned_to => {}} unless @settings[:status_assigned_to] %>
+	@settings = {:status_assigned_to => {}} unless settings['status_assigned_to'] %>
 <fieldset>
   <legend>Issues Status settings</legend>
   <p>
     <label>Check all reachable status</label>
-    <%= check_box_tag 'settings[check_all_status]', true, @settings[:check_all_status] %>
+    <%= check_box_tag 'settings[check_all_status]', true, settings['check_all_status'] %>
   </p>
   <p>
     <label>Add watchers automatically</label>
-    <%= check_box_tag 'settings[add_watcher]', true, @settings[:add_watcher] %>
+    <%= check_box_tag 'settings[add_watcher]', true, settings['add_watcher'] %>
   </p>
   <table class="list">
     <thead><tr>
@@ -22,7 +22,7 @@
       <td><%= h(status.name) %></td>
       <td align="center">
         <%= select_tag	"settings[status_assigned_to][#{status.id}]",
-						options_for_select(options, @settings[:status_assigned_to][status.id.to_s]),
+						options_for_select(options, settings['status_assigned_to'][status.id.to_s]),
 						:include_blank => true %>
 	  </td>
       </tr>

--- a/lib/issues_status_hook.rb
+++ b/lib/issues_status_hook.rb
@@ -12,15 +12,15 @@ class IssueStatusHook < Redmine::Hook::ViewListener
 	
 	def update_issues(issue)
 		plugin = Redmine::Plugin.find(:status_button)
-		setting = Setting["plugin_#{plugin.id}"] || plugin.settings[:default]
+		setting = Setting["plugin_#{plugin.id}"] || plugin.settings['default']
 		status_to_user = {}
-		setting[:status_assigned_to].each { |s, a|
+		setting['status_assigned_to'].each { |s, a|
 			unless a.blank?
 				f = issue.custom_field_values.find { |f| f.custom_field_id == Integer(a) }
 				status_to_user[Integer(s)] = Integer(f.value) if f && f.value && !f.value.empty?
 			end }
 		status_to_user
 		issue.assigned_to_id = status_to_user[issue.status_id] if status_to_user[issue.status_id]
-		issue.watcher_user_ids = issue.watcher_user_ids | status_to_user.map{|s,u| u} if setting[:add_watcher]
+		issue.watcher_user_ids = issue.watcher_user_ids | status_to_user.map{|s,u| u} if setting['add_watcher']
 	end
 end


### PR DESCRIPTION
Thanks for useful plugins.

But,this plugin does not work properly with Redmine 3.4.

I created a patch and worked properly in my Redmine 3.4 environment.

Could you please check and merge?

___

There were two problems in my Redmine 3.4 environment.

Problem 1
Immediately after installing the plugin, you can correctly edit and save the issue.

Create user custom fields and assign them to trackers.

Then an internal error occurs when ticket is edited and saved.

> NoMethodError  (undefined method each' for nil:NilClass): 
> plugins/status_button/lib/issues_status_hook.rb:17:inupdate_issues'
> plugins/status_button/lib/issues_status_hook.rb:10:in `controller_issues_edit_before_save'

Problem 2
On the plugin setting screen, you can not select any custom field to assign to the person in charge of each status.
